### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,1 @@
+[![Board Status](https://dev.azure.com/ShravyaPonuganti/96b08892-43a2-4e52-b863-eafa179b1ad3/399d96c1-7e19-46af-a9ee-578a79f461cc/_apis/work/boardbadge/503fb760-1623-4733-b4a6-3b4b8e16828f)](https://dev.azure.com/ShravyaPonuganti/96b08892-43a2-4e52-b863-eafa179b1ad3/_boards/board/t/399d96c1-7e19-46af-a9ee-578a79f461cc/Microsoft.RequirementCategory)


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://dev.azure.com/ShravyaPonuganti/96b08892-43a2-4e52-b863-eafa179b1ad3/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.